### PR TITLE
This commit introduces support for Windows ARM64 builds in the py4godot

### DIFF
--- a/meson_scripts/copy_tools.py
+++ b/meson_scripts/copy_tools.py
@@ -13,8 +13,7 @@ with open('config.json', 'r') as f:
 
 def strip_platform(text):
     text = text[1:]
-    return text.lstrip("linux64").lstrip("windows64").lstrip("windows32").lstrip("linux32").lstrip("darwin64")
-
+    return text.lstrip("linux64").lstrip("windows64").lstrip("windows32").lstrip("linux32").lstrip("darwin64").lstrip("linuxarm64").lstrip("windowsarm64")
 
 def run(platform):
     # copying all the files from build to the folder of the addon

--- a/meson_scripts/download_python.py
+++ b/meson_scripts/download_python.py
@@ -11,7 +11,7 @@ import stat
 
 platform_dict = {"windows64": "x86_64-pc-windows-msvc-install_only_stripped", "windows32": "i686-pc-windows-msvc-install_only_stripped",
                  "linux64": "x86_64-unknown-linux-gnu-install_only_stripped", "darwin64":"aarch64-apple-darwin-install_only_stripped",
-                 "linuxarm64":"armv7-unknown-linux-gnueabi-install_only_stripped"}
+                 "linuxarm64":"armv7-unknown-linux-gnueabi-install_only_stripped", "windowsarm64":"aarch64-pc-windows-msvc-install_only_stripped"}
 python_files_dir = "python_files"
 copy_dir = "build/final"
 python_ver = "cpython-3.12.4"

--- a/meson_scripts/platform_check.py
+++ b/meson_scripts/platform_check.py
@@ -2,5 +2,16 @@ import struct
 import platform
 
 def get_platform():
-    """Determining the current platform"""
-    return platform.system().lower()+("64" if struct.calcsize("P")*8 == 64 else "")
+    """Return 'windows64' for Windows x86_64, 'windowsarm64' for Windows ARM64"""
+    system = platform.system().lower()
+    arch = platform.machine().lower()
+
+    if system == "windows":
+        if arch in ("aarch64", "arm64"):
+            return "windowsarm64"
+        elif struct.calcsize("P") * 8 == 64:
+            return "windows64"
+
+    # Fallback for other systems if needed
+    return f"{system}{struct.calcsize('P') * 8}"
+

--- a/platforms/windowsarm64.cross
+++ b/platforms/windowsarm64.cross
@@ -1,0 +1,13 @@
+[binaries]
+ar = 'ar'
+strip = 'strip'
+exe_wrapper = ''  # Empty unless you need to run ARM64 binaries on a different host.
+
+[host_machine]
+system = 'windows'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[properties]
+current_platform = 'Windows'

--- a/py4godot/godot_bindings/main.h
+++ b/py4godot/godot_bindings/main.h
@@ -5,7 +5,11 @@
 #include "Python.h"
 
 
-#ifdef _WIN64
+#if defined(_WIN64) && defined(_M_ARM64)
+#define PYTHONHOME L"addons/py4godot/cpython-3.12.4-windowsarm64/python"
+#define PYTHONPATH "addons/py4godot/cpython-3.12.4-windowsarm64/python/Lib/site-packages"
+
+#elif defined(_WIN64)
 #define PYTHONHOME L"addons/py4godot/cpython-3.12.4-windows64/python"
 #define PYTHONPATH "addons/py4godot/cpython-3.12.4-windows64/python/Lib/site-packages"
 


### PR DESCRIPTION
…ot project.

Changes include:
- Adjustments to the build scripts to handle Windows ARM64 architecture.
- Dependencies updated to align with the requirements for this platform.

Known limitations:
- This implementation depends on Python 3.12.4 for Windows ARM64, which is not yet available.
- As a temporary workaround, Python 3.9.7 from jay0lee/CPython-Windows-ARM64 has been considered.

This work follows the same approach as the Linux ARM64 support and is a draft implementation. Feedback is welcome, especially regarding compatibility and potential improvements.